### PR TITLE
Add files required to make a ROS package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>lgsvl</name>
+  <version>2021.1.0</version>
+  <description>A Python API for SVL Simulator</description>
+  <maintainer email="hadi.tabatabaee@lge.com">Hadi Tabatabaee</maintainer>
+  <license>Other</license>
+
+  <depend>python3-environs-pip</depend>
+  <depend>python3-numpy</depend>
+  <depend>python3-websocket</depend>
+  <depend>python3-websockets</depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/lgsvl
+[install]
+install_scripts=$base/lib/lgsvl

--- a/setup.py
+++ b/setup.py
@@ -76,9 +76,16 @@ def get_version(git_tag):
     return public_version_identifier + local_version_label_with_plus
 
 
+package_name = 'lgsvl'
+
 setup(
-    name="lgsvl",
+    name=package_name,
     version=get_version('2021.1'),
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
     description="Python API for SVL Simulator",
     author="LGSVL",
     author_email="contact@svlsimulator.com",
@@ -87,8 +94,9 @@ setup(
     packages=["lgsvl", "lgsvl.dreamview", "lgsvl.evaluator", "lgsvl.wise"],
     install_requires=[
         "environs",
-        "numpy",                # for evaluator
-        "websocket-client",     # for dreamview
+        "numpy",
+        "setuptools",
+        "websocket-client",
         "websockets"
     ],
     setup_requires=[
@@ -99,7 +107,10 @@ setup(
             "flake8>=3.7.0"
         ],
     },
-    license="Other",
+    zip_safe=True,
+    maintainer='Hadi Tabatabaee',
+    maintainer_email='hadi.tabatabaee@lge.com',
+    license='Other',
     classifiers=[
         "License :: Other/Proprietary License",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This adds the necessary files and minor changes to make this Python package also act as a ROS2 package which can be built by `colcon`. This allows ROS2 packages to build this as part of a `colcon` workspace and depend on it directly. To make this a "real" ROS2 package (release-able to the ROS build farm), the package name will need to be changed to something less generic (e.g. `lgsvl-python-api`) but this is a start.

FYI - this PR depends on https://github.com/ros/rosdistro/pull/29356 for `rosdep` to be able to properly resolve the `environs` dependency when included in a ROS workspace. It's not strictly required for this PR to be merged or to build but I thought it was worth mentioning.

Related to https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/merge_requests/916